### PR TITLE
Schema: change clock-format to "24h"

### DIFF
--- a/schemas/org.gnome.shell.extensions.openweather.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.openweather.gschema.xml
@@ -164,7 +164,7 @@
       <summary>Your personal AppKey from developer.mapquest.com</summary>
     </key>
     <key type="s" name="clock-format">
-      <default>'24hr'</default>
+      <default>'24h'</default>
       <summary>Time format for hours</summary>
     </key>
     <key type="i" name="delay-ext-init">


### PR DESCRIPTION
Multiple code paths in the openweather code check whether `_clockFormat === "24h"`.

Fixes #3 (in principle, according to a comment there)
